### PR TITLE
Fix cross compilation

### DIFF
--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -45,3 +45,6 @@ jobs:
 
     - name: Dialyzer
       run: rebar3 dialyzer
+
+    - name: Compile (Rebar2)
+      run: rebar compile

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -19,15 +19,18 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
+	NATIVE_CC = cc
 	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
 	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
+	NATIVE_CC = cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -finline-functions -Wall
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
+	NATIVE_CC = gcc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
 #	CFLAGS ?= -g -std=c99 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -finline-functions -Wall
@@ -66,7 +69,7 @@ $(C_SRC_OUTPUT): fonts.h $(OBJECTS)
 	$(COMPILE_C) $(OUTPUT_OPTION) $<
 
 mk_font: mk_font.c
-	$(c_verbose) $(CC) $< $(FREETYPE_CFLAGS) -lm $(OUTPUT_OPTION)
+	$(c_verbose) $(NATIVE_CC) $< $(FREETYPE_CFLAGS) -lm $(OUTPUT_OPTION)
 
 format:
 	clang-format --style=LLVM -i $(C_FILES)

--- a/c_src/mk_font.c
+++ b/c_src/mk_font.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <freetype2/ft2build.h>
+#include <ft2build.h>
 #include FT_FREETYPE_H
 
 #include "common.h"

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,28 @@
+TweakConfig =
+fun TweakConfig(Config) ->
+        PreAdd = {"(linux|darwin|solaris)",compile, "mv c_src/*.c test"},
+        PostAdd = {"(linux|darwin|solaris)",compile, "mv test/*.c c_src"},
+        {value, {pre_hooks, PreHooksList}, ConfigStrip1} =
+            lists:keytake(pre_hooks, 1, Config),
+        PreHooksList2 = lists:append(PreHooksList, [PreAdd]),
+        Config1 = [{pre_hooks, PreHooksList2} | ConfigStrip1],
+        {value, {post_hooks, PostHooksList}, ConfigStrip2} =
+            lists:keytake(post_hooks, 1, Config1),
+        PostHooksList2 = lists:append(PostHooksList, [PostAdd]),
+        [{post_hooks, PostHooksList2} | ConfigStrip2]
+end,
+
+%% Case copied from ejabberd/rebar.config.script with permission from the copyright holder
+IsRebar3 = case application:get_key(rebar, vsn) of
+	       {ok, VSN} ->
+		   [VSN1 | _] = string:tokens(VSN, "-"),
+		   [Maj|_] = string:tokens(VSN1, "."),
+		   (list_to_integer(Maj) >= 3);
+	       undefined ->
+		   lists:keymember(mix, 1, application:loaded_applications())
+	   end,
+
+case IsRebar3 of
+    false -> TweakConfig(CONFIG);
+    true -> CONFIG
+end.


### PR DESCRIPTION
Ignore the `CC` environment variable for building the `mk_font` utility, as CC might point to a cross compiler while `mk_font` is executed at build time.